### PR TITLE
Winsock Deprecated Warnings "Fix"

### DIFF
--- a/zed_net.h
+++ b/zed_net.h
@@ -184,7 +184,9 @@ ZED_NET_DEF int zed_net_tcp_make_socket_ready(zed_net_socket_t *socket);
 #include <time.h>
 
 #ifdef _WIN32
+#ifdef ZED_NET_IGNORE_DEPRECATION_WARNINGS
 #define _WINSOCK_DEPRECATED_NO_WARNINGS // This "fix" prevents deprecated warnings!
+#endif
 #include <WinSock2.h>
 #pragma comment(lib, "wsock32.lib")
 #else

--- a/zed_net.h
+++ b/zed_net.h
@@ -97,7 +97,7 @@ ZED_NET_DEF const char *zed_net_host_to_str(unsigned int host);
 // Wraps the system handle for a UDP/TCP socket
 typedef struct {
     int handle;
-    int non_blocking;
+    unsigned long non_blocking;
     int ready;
 } zed_net_socket_t;
 
@@ -111,7 +111,7 @@ ZED_NET_DEF void zed_net_socket_close(zed_net_socket_t *socket);
 //
 // Returns 0 on success
 // Returns -1 on failure (call 'zed_net_get_error' for more info)
-ZED_NET_DEF int zed_net_udp_socket_open(zed_net_socket_t *socket, unsigned int port, int non_blocking);
+ZED_NET_DEF int zed_net_udp_socket_open(zed_net_socket_t *socket, unsigned int port, unsigned long non_blocking);
 
 // Closes a previously opened socket
 ZED_NET_DEF void zed_net_socket_close(zed_net_socket_t *socket);
@@ -140,7 +140,7 @@ ZED_NET_DEF int zed_net_udp_socket_receive(zed_net_socket_t *socket, zed_net_add
 // Socket will listen for incoming connections if 'listen_socket' is non-zero
 // Returns 0 on success
 // Returns -1 on failure (call 'zed_net_get_error' for more info)
-ZED_NET_DEF int zed_net_tcp_socket_open(zed_net_socket_t *socket, unsigned int port, int non_blocking, int listen_socket);
+ZED_NET_DEF int zed_net_tcp_socket_open(zed_net_socket_t *socket, unsigned int port, unsigned long non_blocking, int listen_socket);
 
 // Connect to a remote endpoint
 // Returns 0 on success.
@@ -184,6 +184,7 @@ ZED_NET_DEF int zed_net_tcp_make_socket_ready(zed_net_socket_t *socket);
 #include <time.h>
 
 #ifdef _WIN32
+#define _WINSOCK_DEPRECATED_NO_WARNINGS // This "fix" prevents deprecated warnings!
 #include <WinSock2.h>
 #pragma comment(lib, "wsock32.lib")
 #else
@@ -254,7 +255,7 @@ ZED_NET_DEF const char *zed_net_host_to_str(unsigned int host) {
     return inet_ntoa(in);
 }
 
-ZED_NET_DEF int zed_net_udp_socket_open(zed_net_socket_t *sock, unsigned int port, int non_blocking) {
+ZED_NET_DEF int zed_net_udp_socket_open(zed_net_socket_t *sock, unsigned int port, unsigned long non_blocking) {
     if (!sock)
         return zed_net__error("Socket is NULL");
 
@@ -296,7 +297,7 @@ ZED_NET_DEF int zed_net_udp_socket_open(zed_net_socket_t *sock, unsigned int por
     return 0;
 }
 
-ZED_NET_DEF int zed_net_tcp_socket_open(zed_net_socket_t *sock, unsigned int port, int non_blocking, int listen_socket) {
+ZED_NET_DEF int zed_net_tcp_socket_open(zed_net_socket_t *sock, unsigned int port, unsigned long non_blocking, int listen_socket) {
     if (!sock)
         return zed_net__error("Socket is NULL");
 


### PR DESCRIPTION
Prevents Winsock Deprecated Warnings, which currently appear because of deprecated functions are in use and require `#define _WINSOCK_DEPRECATED_NO_WARNINGS`, I've also made `non_blocking` an unsigned long instead of an int, because Visual Studio 2017 is throwing a compiler error trying to convert an int * to a u_long *.